### PR TITLE
fix: import edge cases / changes

### DIFF
--- a/dbops.go
+++ b/dbops.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/glebarez/sqlite"
@@ -232,7 +233,10 @@ func convertDetectionToNote(detection *Detection) Note {
 		detection.Date = parsedDate.Format("2006-01-02")
 	}
 
-	clipName := GenerateClipName(detection)
+	// Construct the path for the clip
+	year := parsedDate.Format("2006")
+	month := parsedDate.Format("01")
+	clipName := filepath.Join(year, month, GenerateClipName(detection))
 
 	return Note{
 		Date:           detection.Date,

--- a/fileops.go
+++ b/fileops.go
@@ -75,8 +75,14 @@ func handleFileTransferWithFS(detection *Detection, sourceFilesDir, targetFilesD
 
 	// Check if the source file exists
 	if !fs.FileExists(sourceFilePath) {
-		log.Printf("Source file not found: %s", sourceFilePath)
-		return
+		// detection.ComName may have had spaces replaced with underscores and apostrophe's removed
+		comNameFormatted := strings.ReplaceAll(detection.ComName, " ", "_")
+		comNameFormatted = strings.ReplaceAll(comNameFormatted, "'", "")
+		sourceFilePath = filepath.Join(sourceFilesDir, "Extracted", "By_Date", detection.Date, comNameFormatted, detection.FileName)
+		if !fs.FileExists(sourceFilePath) {
+			log.Printf("Source file not found: %s", sourceFilePath)
+			return
+		}
 	}
 
 	// Generate a new filename that follows the BIRDNET-Pi naming convention

--- a/fileops.go
+++ b/fileops.go
@@ -223,7 +223,7 @@ func GenerateClipName(detection *Detection) string {
 
 	// Generate the new filename with the formatted date, time, and confidence level.
 	confidencePercentage := fmt.Sprintf("%dp", int(detection.Confidence*100))
-	newFileName := fmt.Sprintf("%s_%s_%s.wav", sciNameFormatted, confidencePercentage, formattedDateTime)
+	newFileName := fmt.Sprintf("%s_%s_%s%s", sciNameFormatted, confidencePercentage, formattedDateTime, filepath.Ext(detection.FileName))
 
 	return newFileName
 }

--- a/special_paths_test.go
+++ b/special_paths_test.go
@@ -104,8 +104,8 @@ func TestFilePathsWithSpecialCharacters(t *testing.T) {
 			handleFileTransferWithFS(detection, sourceDir, targetDir, CopyFile, mockFS)
 
 			// Create expected target path
-			clipName := GenerateClipName(detection)
-			expectedTargetPath := filepath.Join(targetDir, "2023", "01", clipName)
+			clipName := filepath.Join("2023", "01", GenerateClipName(detection))
+			expectedTargetPath := filepath.Join(targetDir, clipName)
 
 			// Verify the file was copied successfully
 			if !mockFS.FileExists(expectedTargetPath) {

--- a/special_paths_test.go
+++ b/special_paths_test.go
@@ -63,12 +63,12 @@ func TestFilePathsWithSpecialCharacters(t *testing.T) {
 			fileName:  "recording with spaces.wav",
 			expectErr: false,
 		},
-		// It also strips some characters
+		// It also strips some characters and uses mp3s
 		{
 			name:      "Spaces in names changed to underscores",
 			birdName:  "Anna's_Hummingbird",
 			comName:   "Annas_Hummingbird",
-			fileName:  "recording with spaces.wav",
+			fileName:  "recording with spaces.mp3",
 			expectErr: false,
 		},
 	}

--- a/special_paths_test.go
+++ b/special_paths_test.go
@@ -15,6 +15,7 @@ func TestFilePathsWithSpecialCharacters(t *testing.T) {
 	testCases := []struct {
 		name      string
 		birdName  string
+		comName   string
 		fileName  string
 		expectErr bool
 	}{
@@ -54,6 +55,22 @@ func TestFilePathsWithSpecialCharacters(t *testing.T) {
 			fileName:  "mixed-recording!@$%^.wav",
 			expectErr: false,
 		},
+		// Looks like Birdnet-pi started adding underscores to common name at some point
+		{
+			name:      "Spaces in names changed to underscores",
+			birdName:  "Test Bird With Spaces",
+			comName:   "Test_Bird_With_Spaces",
+			fileName:  "recording with spaces.wav",
+			expectErr: false,
+		},
+		// It also strips some characters
+		{
+			name:      "Spaces in names changed to underscores",
+			birdName:  "Anna's_Hummingbird",
+			comName:   "Annas_Hummingbird",
+			fileName:  "recording with spaces.wav",
+			expectErr: false,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -68,10 +85,16 @@ func TestFilePathsWithSpecialCharacters(t *testing.T) {
 				FileName:   tc.fileName,
 			}
 
+			// Use tc.ComName override, if it exists
+			comName := tc.comName
+			if comName == "" {
+				comName = tc.birdName
+			}
+
 			// Setup source directories and file
 			sourceDir := "/source/" + tc.name
 			targetDir := "/target/" + tc.name
-			sourcePath := filepath.Join(sourceDir, "Extracted", "By_Date", detection.Date, detection.ComName, detection.FileName)
+			sourcePath := filepath.Join(sourceDir, "Extracted", "By_Date", detection.Date, comName, detection.FileName)
 
 			// Create source directory structure and file
 			mockFS.MkdirAll(filepath.Dir(sourcePath), 0o755)


### PR DESCRIPTION
I ran into some issues while importing my recent birdnet-pi data.

The specific issues were:

1. It seems like bird names with spaces get converted to underscores now. I left the behavior that first checks for the name with a space and added a check with an underscore
2. Apostrophes are stripped from names
3. The sqlite db is expecting the clipname to include year/month in the filename but the import script wasn't setting those
4. Preserve the audio file extension (though it's not perfect since my birdnet-pi mp3 files are stereo which the UI isn't expecting)

Fixes #24 